### PR TITLE
Calculate in_general using year/month/day difference

### DIFF
--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -4,24 +4,22 @@ require "active_support/all"
 class TimeDifference
 
   def self.between(start_date, end_date)
-  	@start_date, @end_date = start_date, end_date
-  	self
+    @start_date, @end_date = start_date, end_date
+    self
   end
 
   class << self
-
-  	[:years, :months, :weeks, :days, :hours, :minutes, :seconds].each do |time_component|
-  		self.class.instance_eval do
-  			define_method("in_#{time_component}") do
-  				if time_component == :months
-  					((@time_diff/(1.days * 30.42)).round(2)).abs
-  				else
-  			 		((@time_diff/1.send(time_component)).round(2)).abs
-  			 	end
-  			end
-  		end
-  	end
-
+    [:years, :months, :weeks, :days, :hours, :minutes, :seconds].each do |time_component|
+      self.class.instance_eval do
+        define_method("in_#{time_component}") do
+          if time_component == :months
+            ((@time_diff/(1.days * 30.42)).round(2)).abs
+          else
+            ((@time_diff/1.send(time_component)).round(2)).abs
+          end
+        end
+      end
+    end
   end
 
   def self.in_each_component
@@ -40,7 +38,9 @@ class TimeDifference
     years = @end_date.year - @start_date.year
     months = @end_date.month - @start_date.month
     # Get # of days in previous month of end_date
-    previous_days_in_month = Time.days_in_month(@end_date.month - 1, @end_date.year)
+    previous_month = @end_date.month == 1 ? 12 : @end_date.month - 1
+    previous_year = @end_date.month == 1 ? @end_date.year - 1 : @end_date.year
+    previous_days_in_month = Time.days_in_month(previous_month, previous_year)
     # Then subtract difference between the day values
     day_difference = @end_date.day - @start_date.day
     # Lose one month and add day_difference offset
@@ -54,12 +54,11 @@ class TimeDifference
     # If months is less than 0, add 12 and subtract one from year
     if months < 0
       months += 12
-      years -=1
+      years -= 1
     end
     # If days is negative, subtract 1 from months
     weeks = (days / 7).to_i
     days %= 7
-  	{years: years, months: months, weeks: weeks, days: days}
+    { years: years, months: months, weeks: weeks, days: days }
   end
-
 end

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -3,8 +3,8 @@ require "active_support/all"
 
 class TimeDifference
 
-  def self.between(start_time, end_time)
-  	@time_diff = end_time - start_time
+  def self.between(start_date, end_date)
+  	@start_date, @end_date = start_date, end_date
   	self
   end
 
@@ -37,12 +37,29 @@ class TimeDifference
   end
 
   def self.in_general
-  	result = {}
-	  [:years, :months, :weeks, :days, :hours, :minutes, :seconds].each do |time_component|
-  		result[time_component] = (@time_diff/1.send(time_component)).floor
-  		@time_diff = (@time_diff - result[time_component].send(time_component))
-  	end
-  	result
+    years = @end_date.year - @start_date.year
+    months = @end_date.month - @start_date.month
+    # Get # of days in previous month of end_date
+    previous_days_in_month = Time.days_in_month(@end_date.month - 1, @end_date.year)
+    # Then subtract difference between the day values
+    day_difference = @end_date.day - @start_date.day
+    # Lose one month and add day_difference offset
+    if day_difference < 0
+      months -= 1
+      # If months is less than 0, add 12 and subtract one from year
+      if months < 0
+        months += 12
+        year -=1
+      end
+      days = previous_days_in_month + day_difference
+    # Number of months stays the same but day difference is the number of days
+    else
+      days = day_difference
+    end
+    # If days is negative, subtract 1 from months
+    weeks = (days / 7).to_i
+    days %= 7
+  	{years: years, months: months, weeks: weeks, days: days}
   end
 
 end

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -46,15 +46,15 @@ class TimeDifference
     # Lose one month and add day_difference offset
     if day_difference < 0
       months -= 1
-      # If months is less than 0, add 12 and subtract one from year
-      if months < 0
-        months += 12
-        year -=1
-      end
       days = previous_days_in_month + day_difference
     # Number of months stays the same but day difference is the number of days
     else
       days = day_difference
+    end
+    # If months is less than 0, add 12 and subtract one from year
+    if months < 0
+      months += 12
+      years -=1
     end
     # If days is negative, subtract 1 from months
     weeks = (days / 7).to_i


### PR DESCRIPTION
...instead of calculating by day difference and assuming static values for year to day conversion, etc.

For example, 1 year is not 360 days nor even 365 days. Need to have two dates in context.
Downside is in_general can't be called with values like 5.days that have no date value.