### PR TITLE
Fix DateTime class issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - "1.9.3"
+  - 2.2
   - jruby-19mode # JRuby in 1.9 mode
   - rbx-19mode
 # uncomment this line if your project needs to run something other than `rake`:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ rvm:
   - rbx-19mode
 # uncomment this line if your project needs to run something other than `rake`:
 script: bundle exec rspec spec
+gemfile:
+- Gemfile.activesupport32
+- Gemfile

--- a/Gemfile.activesupport32
+++ b/Gemfile.activesupport32
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gemspec
+
+gem 'activesupport', '~> 3.2'

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -3,54 +3,73 @@ require "active_support/all"
 
 class TimeDifference
 
+  private_class_method :new
+
+  TIME_COMPONENTS = [:years, :months, :weeks, :days, :hours, :minutes, :seconds]
+
   def self.between(start_time, end_time)
+    new(start_time, end_time)
+  end
+
+  def in_years
+    in_component(:years)
+  end
+
+  def in_months
+    (@time_diff / (1.day * 30.42)).round(2)
+  end
+
+  def in_weeks
+    in_component(:weeks)
+  end
+
+  def in_days
+    in_component(:days)
+  end
+
+  def in_hours
+    in_component(:hours)
+  end
+
+  def in_minutes
+    in_component(:minutes)
+  end
+
+  def in_seconds
+    @time_diff
+  end
+
+  def in_each_component
+    Hash[TIME_COMPONENTS.map do |time_component|
+      [time_component, public_send("in_#{time_component}")]
+    end]
+  end
+
+  def in_general
+    remaining = @time_diff
+
+    Hash[TIME_COMPONENTS.map do |time_component|
+      rounded_time_component = (remaining / 1.send(time_component)).floor
+      remaining -= rounded_time_component.send(time_component)
+
+      [time_component, rounded_time_component]
+    end]
+  end
+
+  private
+  def initialize(start_time, end_time)
     start_time = time_in_seconds(start_time)
     end_time = time_in_seconds(end_time)
 
-    @time_diff = end_time - start_time
-
-    self
+    @time_diff = (end_time - start_time).abs
   end
 
-  def self.time_in_seconds(time)
+  def time_in_seconds(time)
     time.to_time.to_f
   end
 
-  class << self
-
-    [:years, :months, :weeks, :days, :hours, :minutes, :seconds].each do |time_component|
-      self.class.instance_eval do
-        define_method("in_#{time_component}") do
-          if time_component == :months
-            ((@time_diff/(1.days * 30.42)).round(2)).abs
-          else
-            ((@time_diff/1.send(time_component)).round(2)).abs
-          end
-        end
-      end
-    end
-
-  end
-
-  def self.in_each_component
-    time_in_each_component = {}
-    [:years, :months, :weeks, :days, :hours, :minutes, :seconds].each do |time_component|
-      if time_component == :months
-        time_in_each_component[time_component] = ((@time_diff/(1.days * 30.42)).round(2)).abs
-      else
-        time_in_each_component[time_component] = ((@time_diff/1.send(time_component)).round(2)).abs
-      end
-    end
-    time_in_each_component
-  end
-
-  def self.in_general
-    result = {}
-    [:years, :months, :weeks, :days, :hours, :minutes, :seconds].each do |time_component|
-      result[time_component] = (@time_diff/1.send(time_component)).floor
-      @time_diff = (@time_diff - result[time_component].send(time_component))
-    end
-    result
+  def in_component(component)
+    (@time_diff / 1.send(component)).round(2)
   end
 
 end

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -4,8 +4,16 @@ require "active_support/all"
 class TimeDifference
 
   def self.between(start_time, end_time)
-    @time_diff = end_time.to_time - start_time.to_time
+    start_time = time_in_seconds(start_time)
+    end_time = time_in_seconds(end_time)
+
+    @time_diff = end_time - start_time
+
     self
+  end
+
+  def self.time_in_seconds(time)
+    time.to_time.to_f
   end
 
   class << self

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -4,7 +4,7 @@ require "active_support/all"
 class TimeDifference
 
   def self.between(start_time, end_time)
-  	@time_diff = end_time - start_time
+  	@time_diff = end_time.to_time - start_time.to_time
   	self
   end
 

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -4,23 +4,23 @@ require "active_support/all"
 class TimeDifference
 
   def self.between(start_time, end_time)
-  	@time_diff = end_time.to_time - start_time.to_time
-  	self
+    @time_diff = end_time.to_time - start_time.to_time
+    self
   end
 
   class << self
 
-  	[:years, :months, :weeks, :days, :hours, :minutes, :seconds].each do |time_component|
-  		self.class.instance_eval do
-  			define_method("in_#{time_component}") do
-  				if time_component == :months
-  					((@time_diff/(1.days * 30.42)).round(2)).abs
-  				else
-  			 		((@time_diff/1.send(time_component)).round(2)).abs
-  			 	end
-  			end
-  		end
-  	end
+    [:years, :months, :weeks, :days, :hours, :minutes, :seconds].each do |time_component|
+      self.class.instance_eval do
+        define_method("in_#{time_component}") do
+          if time_component == :months
+            ((@time_diff/(1.days * 30.42)).round(2)).abs
+          else
+            ((@time_diff/1.send(time_component)).round(2)).abs
+          end
+        end
+      end
+    end
 
   end
 
@@ -37,12 +37,12 @@ class TimeDifference
   end
 
   def self.in_general
-  	result = {}
-	  [:years, :months, :weeks, :days, :hours, :minutes, :seconds].each do |time_component|
-  		result[time_component] = (@time_diff/1.send(time_component)).floor
-  		@time_diff = (@time_diff - result[time_component].send(time_component))
-  	end
-  	result
+    result = {}
+    [:years, :months, :weeks, :days, :hours, :minutes, :seconds].each do |time_component|
+      result[time_component] = (@time_diff/1.send(time_component)).floor
+      @time_diff = (@time_diff - result[time_component].send(time_component))
+    end
+    result
   end
 
 end

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -2,127 +2,170 @@ require 'spec_helper'
 
 describe TimeDifference do
 
-  context "Time class" do
-    it "returns time difference in each component" do
-      start_time = Time.new(2011, 1)
-      end_time = Time.new(2011, 12)
-      expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years => 0.91, :months => 10.98, :weeks => 47.71, :days => 334.0, :hours => 8016.0, :minutes => 480960.0, :seconds => 28857600.0})
-    end
+  def self.with_each_class(&block)
+    classes = [Time, Date, DateTime]
 
-    it "returns time difference in general that matches the total seconds" do
-      start_time = Time.new(2009, 11)
-      end_time = Time.new(2011, 1)
-      expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years => 1, :months => 2, :weeks => 0, :days => 0, :hours => 18, :minutes => 0, :seconds => 0})
+    classes.each do |clazz|
+      context "with a #{clazz.name} class" do
+        instance_exec clazz, &block
+      end
     end
-
-    it "returns time difference based on Wolfram Alpha" do
-      start_time = Time.new(2011, 1)
-      end_time = Time.new(2011, 12)
-      expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
-      expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
-      expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
-      expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
-      expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
-      expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
-    end
-
-    it "returns time difference in absolute value regardless how it is minus-ed out" do
-      start_time = Time.new(2011, 1)
-      end_time = Time.new(2011, 12)
-      expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
-      expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
-      expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
-      expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
-      expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
-      expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
-    end
-
   end
 
-  context "with DateTime class" do
+  describe ".between" do
+    it "returns a new TimeDifference instance" do
+      start_time = Time.new(2011, 1)
+      end_time = Time.new(2011, 12)
 
-    it "returns time difference in each component" do
-      start_time = DateTime.new(2011, 1)
-      end_time = DateTime.new(2011, 12)
-      expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years => 0.91, :months => 10.98, :weeks => 47.71, :days => 334.0, :hours => 8016.0, :minutes => 480960.0, :seconds => 28857600.0})
+      expect(TimeDifference.between(start_time, end_time)).to be_a(TimeDifference)
     end
-
-    it "returns time difference in general that matches the total seconds" do
-      start_time = DateTime.new(2009, 11)
-      end_time = DateTime.new(2011, 1)
-      expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years => 1, :months => 2, :weeks => 0, :days => 0, :hours => 18, :minutes => 0, :seconds => 0})
-    end
-
-    it "returns time difference based on Wolfram Alpha" do
-      start_time = DateTime.new(2011, 1)
-      end_time = DateTime.new(2011, 12)
-      expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
-      expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
-      expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
-      expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
-      expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
-      expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
-    end
-
-    it "returns time difference when given a DateTime with a timezone offset" do
-      start_time = DateTime.parse('2011-01-01 00:00:00+4')
-      end_time = DateTime.parse('2011-12-01 00:00:00+4')
-      expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
-      expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
-      expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
-      expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
-      expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
-      expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
-    end
-
-    it "returns time difference in absolute value regardless how it is minus-ed out" do
-      start_time = DateTime.new(2011, 1)
-      end_time = DateTime.new(2011, 12)
-      expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
-      expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
-      expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
-      expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
-      expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
-      expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
-    end
-
   end
 
-  context "Date class" do
-    it "returns time difference in each component" do
-      start_time = Date.new(2011, 1)
-      end_time = Date.new(2011, 12)
-      expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years => 0.91, :months => 10.98, :weeks => 47.71, :days => 334.0, :hours => 8016.0, :minutes => 480960.0, :seconds => 28857600.0})
-    end
+  describe "#in_each_component" do
+    with_each_class do |clazz|
+      it "returns time difference in each component" do
+        start_time = clazz.new(2011, 1)
+        end_time = clazz.new(2011, 12)
 
-    it "returns time difference in general that matches the total seconds" do
-      start_time = Date.new(2009, 11)
-      end_time = Date.new(2011, 1)
-      expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years => 1, :months => 2, :weeks => 0, :days => 0, :hours => 18, :minutes => 0, :seconds => 0})
+        expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years => 0.91, :months => 10.98, :weeks => 47.71, :days => 334.0, :hours => 8016.0, :minutes => 480960.0, :seconds => 28857600.0})
+      end
     end
-
-    it "returns time difference based on Wolfram Alpha" do
-      start_time = Date.new(2011, 1)
-      end_time = Date.new(2011, 12)
-      expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
-      expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
-      expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
-      expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
-      expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
-      expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
-    end
-
-    it "returns time difference in absolute value regardless how it is minus-ed out" do
-      start_time = Date.new(2011, 1)
-      end_time = Date.new(2011, 12)
-      expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
-      expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
-      expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
-      expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
-      expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
-      expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
-    end
-
   end
 
+  describe "#in_general" do
+    with_each_class do |clazz|
+      it "returns time difference in general that matches the total seconds" do
+        start_time = clazz.new(2009, 11)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years => 1, :months => 2, :weeks => 0, :days => 0, :hours => 18, :minutes => 0, :seconds => 0})
+      end
+    end
+  end
+
+  describe "#in_years" do
+    with_each_class do |clazz|
+      it "returns time difference in years based on Wolfram Alpha" do
+        start_time = clazz.new(2011, 1)
+        end_time = clazz.new(2011, 12)
+
+        expect(TimeDifference.between(start_time, end_time).in_years).to eql(0.91)
+      end
+
+      it "returns an absolute difference" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(start_time, end_time).in_years).to eql(0.91)
+      end
+    end
+  end
+
+  describe "#in_months" do
+    with_each_class do |clazz|
+      it "returns time difference in months based on Wolfram Alpha" do
+        start_time = clazz.new(2011, 1)
+        end_time = clazz.new(2011, 12)
+
+        expect(TimeDifference.between(start_time, end_time).in_months).to eql(10.98)
+      end
+
+      it "returns an absolute difference" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(start_time, end_time).in_months).to eql(10.98)
+      end
+    end
+  end
+
+  describe "#in_weeks" do
+    with_each_class do |clazz|
+      it "returns time difference in weeks based on Wolfram Alpha" do
+        start_time = clazz.new(2011, 1)
+        end_time = clazz.new(2011, 12)
+
+        expect(TimeDifference.between(start_time, end_time).in_weeks).to eql(47.71)
+      end
+
+      it "returns an absolute difference" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(start_time, end_time).in_weeks).to eql(47.71)
+      end
+    end
+  end
+
+  describe "#in_days" do
+    with_each_class do |clazz|
+      it "returns time difference in weeks based on Wolfram Alpha" do
+        start_time = clazz.new(2011, 1)
+        end_time = clazz.new(2011, 12)
+
+        expect(TimeDifference.between(start_time, end_time).in_days).to eql(334.0)
+      end
+
+      it "returns an absolute difference" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(start_time, end_time).in_days).to eql(334.0)
+      end
+    end
+  end
+
+  describe "#in_hours" do
+    with_each_class do |clazz|
+      it "returns time difference in hours based on Wolfram Alpha" do
+        start_time = clazz.new(2011, 1)
+        end_time = clazz.new(2011, 12)
+
+        expect(TimeDifference.between(start_time, end_time).in_hours).to eql(8016.0)
+      end
+
+      it "returns an absolute difference" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(start_time, end_time).in_hours).to eql(8016.0)
+      end
+    end
+  end
+
+  describe "#in_minutes" do
+    with_each_class do |clazz|
+      it "returns time difference in minutes based on Wolfram Alpha" do
+        start_time = clazz.new(2011, 1)
+        end_time = clazz.new(2011, 12)
+
+        expect(TimeDifference.between(start_time, end_time).in_minutes).to eql(480960.0)
+      end
+
+      it "returns an absolute difference" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(start_time, end_time).in_minutes).to eql(480960.0)
+      end
+    end
+  end
+
+  describe "#in_seconds" do
+    with_each_class do |clazz|
+      it "returns time difference in seconds based on Wolfram Alpha" do
+        start_time = clazz.new(2011, 1)
+        end_time = clazz.new(2011, 12)
+
+        expect(TimeDifference.between(start_time, end_time).in_seconds).to eql(28857600.0)
+      end
+
+      it "returns an absolute difference" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(start_time, end_time).in_seconds).to eql(28857600.0)
+      end
+    end
+  end
 end

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -10,8 +10,8 @@ describe TimeDifference do
 		end
 	
 		it "returns time difference in general that matches the total seconds" do
-			start_time = Time.new(2009,9)
-			end_time = Time.new(2010,11)
+			start_time = Time.new(2009,11)
+			end_time = Time.new(2011,1)
 			expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years=>1, :months=>2, :weeks=>0, :days=>0, :hours=>18, :minutes=>0, :seconds=>0})
 		end
 	
@@ -48,8 +48,8 @@ describe TimeDifference do
 		end
 	
 		it "returns time difference in general that matches the total seconds" do
-			start_time = DateTime.new(2009,9)
-			end_time = DateTime.new(2010,11)
+			start_time = DateTime.new(2009,11)
+			end_time = DateTime.new(2011,1)
 			expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years=>1, :months=>2, :weeks=>0, :days=>0, :hours=>18, :minutes=>0, :seconds=>0})
 		end
 	
@@ -85,8 +85,8 @@ describe TimeDifference do
 		end
 	
 		it "returns time difference in general that matches the total seconds" do
-			start_time = Date.new(2009,9)
-			end_time = Date.new(2010,11)
+			start_time = Date.new(2009,11)
+			end_time = Date.new(2011,1)
 			expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years=>1, :months=>2, :weeks=>0, :days=>0, :hours=>18, :minutes=>0, :seconds=>0})
 		end
 	

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -2,38 +2,116 @@ require 'spec_helper'
 
 describe TimeDifference do
 
-	it "returns time difference in each component" do
-		start_time = Time.new(2011,1)
-		end_time = Time.new(2011,12)
-		expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years=>0.91, :months=>10.98, :weeks=>47.71, :days=>334.0, :hours=>8016.0, :minutes=>480960.0, :seconds=>28857600.0})
+	context "Time class" do
+		it "returns time difference in each component" do
+			start_time = Time.new(2011,1)
+			end_time = Time.new(2011,12)
+			expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years=>0.91, :months=>10.98, :weeks=>47.71, :days=>334.0, :hours=>8016.0, :minutes=>480960.0, :seconds=>28857600.0})
+		end
+	
+		it "returns time difference in general that matches the total seconds" do
+			start_time = Time.new(2009,9)
+			end_time = Time.new(2010,11)
+			expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years=>1, :months=>2, :weeks=>0, :days=>0, :hours=>18, :minutes=>0, :seconds=>0})
+		end
+	
+		it "returns time difference based on Wolfram Alpha" do
+			start_time = Time.new(2011,1)
+			end_time = Time.new(2011,12)
+			expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
+			expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
+			expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
+			expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
+			expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
+			expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
+		end
+	
+		it "returns time difference in absolute value regardless how it is minus-ed out" do
+			start_time = Time.new(2011,1)
+			end_time = Time.new(2011,12)
+			expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
+			expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
+			expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
+			expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
+			expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
+			expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
+		end
+
 	end
 
-	it "returns time difference in general that matches the total seconds" do
-		start_time = Time.new(2009,9)
-		end_time = Time.new(2010,11)
-		expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years=>1, :months=>2, :weeks=>0, :days=>0, :hours=>18, :minutes=>0, :seconds=>0})
+	context "with DateTime class" do
+
+		it "returns time difference in each component" do
+			start_time = DateTime.new(2011,1)
+			end_time = DateTime.new(2011,12)
+			expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years=>0.91, :months=>10.98, :weeks=>47.71, :days=>334.0, :hours=>8016.0, :minutes=>480960.0, :seconds=>28857600.0})
+		end
+	
+		it "returns time difference in general that matches the total seconds" do
+			start_time = DateTime.new(2009,9)
+			end_time = DateTime.new(2010,11)
+			expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years=>1, :months=>2, :weeks=>0, :days=>0, :hours=>18, :minutes=>0, :seconds=>0})
+		end
+	
+		it "returns time difference based on Wolfram Alpha" do
+			start_time = DateTime.new(2011,1)
+			end_time = DateTime.new(2011,12)
+			expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
+			expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
+			expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
+			expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
+			expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
+			expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
+		end
+	
+		it "returns time difference in absolute value regardless how it is minus-ed out" do
+			start_time = DateTime.new(2011,1)
+			end_time = DateTime.new(2011,12)
+			expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
+			expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
+			expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
+			expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
+			expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
+			expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
+		end
+
 	end
 
-	it "returns time difference based on Wolfram Alpha" do
-		start_time = Time.new(2011,1)
-		end_time = Time.new(2011,12)
-		expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
-		expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
-		expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
-		expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
-		expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
-		expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
-	end
+	context "Date class" do
+		it "returns time difference in each component" do
+			start_time = Date.new(2011,1)
+			end_time = Date.new(2011,12)
+			expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years=>0.91, :months=>10.98, :weeks=>47.71, :days=>334.0, :hours=>8016.0, :minutes=>480960.0, :seconds=>28857600.0})
+		end
+	
+		it "returns time difference in general that matches the total seconds" do
+			start_time = Date.new(2009,9)
+			end_time = Date.new(2010,11)
+			expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years=>1, :months=>2, :weeks=>0, :days=>0, :hours=>18, :minutes=>0, :seconds=>0})
+		end
+	
+		it "returns time difference based on Wolfram Alpha" do
+			start_time = Date.new(2011,1)
+			end_time = Date.new(2011,12)
+			expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
+			expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
+			expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
+			expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
+			expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
+			expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
+		end
+	
+		it "returns time difference in absolute value regardless how it is minus-ed out" do
+			start_time = Date.new(2011,1)
+			end_time = Date.new(2011,12)
+			expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
+			expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
+			expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
+			expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
+			expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
+			expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
+		end
 
-	it "returns time difference in absolute value regardless how it is minus-ed out" do
-		start_time = Time.new(2011,1)
-		end_time = Time.new(2011,12)
-		expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
-		expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
-		expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
-		expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
-		expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
-		expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
 	end
 
 end

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -64,6 +64,17 @@ describe TimeDifference do
       expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
     end
 
+    it "returns time difference when given a DateTime with a timezone offset" do
+      start_time = DateTime.parse('2011-01-01 00:00:00+4')
+      end_time = DateTime.parse('2011-12-01 00:00:00+4')
+      expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
+      expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
+      expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
+      expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
+      expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
+      expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
+    end
+
     it "returns time difference in absolute value regardless how it is minus-ed out" do
       start_time = DateTime.new(2011, 1)
       end_time = DateTime.new(2011, 12)

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -2,116 +2,116 @@ require 'spec_helper'
 
 describe TimeDifference do
 
-	context "Time class" do
-		it "returns time difference in each component" do
-			start_time = Time.new(2011,1)
-			end_time = Time.new(2011,12)
-			expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years=>0.91, :months=>10.98, :weeks=>47.71, :days=>334.0, :hours=>8016.0, :minutes=>480960.0, :seconds=>28857600.0})
-		end
-	
-		it "returns time difference in general that matches the total seconds" do
-			start_time = Time.new(2009,11)
-			end_time = Time.new(2011,1)
-			expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years=>1, :months=>2, :weeks=>0, :days=>0, :hours=>18, :minutes=>0, :seconds=>0})
-		end
-	
-		it "returns time difference based on Wolfram Alpha" do
-			start_time = Time.new(2011,1)
-			end_time = Time.new(2011,12)
-			expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
-			expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
-			expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
-			expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
-			expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
-			expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
-		end
-	
-		it "returns time difference in absolute value regardless how it is minus-ed out" do
-			start_time = Time.new(2011,1)
-			end_time = Time.new(2011,12)
-			expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
-			expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
-			expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
-			expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
-			expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
-			expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
-		end
+  context "Time class" do
+    it "returns time difference in each component" do
+      start_time = Time.new(2011, 1)
+      end_time = Time.new(2011, 12)
+      expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years => 0.91, :months => 10.98, :weeks => 47.71, :days => 334.0, :hours => 8016.0, :minutes => 480960.0, :seconds => 28857600.0})
+    end
 
-	end
+    it "returns time difference in general that matches the total seconds" do
+      start_time = Time.new(2009, 11)
+      end_time = Time.new(2011, 1)
+      expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years => 1, :months => 2, :weeks => 0, :days => 0, :hours => 18, :minutes => 0, :seconds => 0})
+    end
 
-	context "with DateTime class" do
+    it "returns time difference based on Wolfram Alpha" do
+      start_time = Time.new(2011, 1)
+      end_time = Time.new(2011, 12)
+      expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
+      expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
+      expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
+      expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
+      expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
+      expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
+    end
 
-		it "returns time difference in each component" do
-			start_time = DateTime.new(2011,1)
-			end_time = DateTime.new(2011,12)
-			expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years=>0.91, :months=>10.98, :weeks=>47.71, :days=>334.0, :hours=>8016.0, :minutes=>480960.0, :seconds=>28857600.0})
-		end
-	
-		it "returns time difference in general that matches the total seconds" do
-			start_time = DateTime.new(2009,11)
-			end_time = DateTime.new(2011,1)
-			expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years=>1, :months=>2, :weeks=>0, :days=>0, :hours=>18, :minutes=>0, :seconds=>0})
-		end
-	
-		it "returns time difference based on Wolfram Alpha" do
-			start_time = DateTime.new(2011,1)
-			end_time = DateTime.new(2011,12)
-			expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
-			expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
-			expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
-			expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
-			expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
-			expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
-		end
-	
-		it "returns time difference in absolute value regardless how it is minus-ed out" do
-			start_time = DateTime.new(2011,1)
-			end_time = DateTime.new(2011,12)
-			expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
-			expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
-			expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
-			expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
-			expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
-			expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
-		end
+    it "returns time difference in absolute value regardless how it is minus-ed out" do
+      start_time = Time.new(2011, 1)
+      end_time = Time.new(2011, 12)
+      expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
+      expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
+      expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
+      expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
+      expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
+      expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
+    end
 
-	end
+  end
 
-	context "Date class" do
-		it "returns time difference in each component" do
-			start_time = Date.new(2011,1)
-			end_time = Date.new(2011,12)
-			expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years=>0.91, :months=>10.98, :weeks=>47.71, :days=>334.0, :hours=>8016.0, :minutes=>480960.0, :seconds=>28857600.0})
-		end
-	
-		it "returns time difference in general that matches the total seconds" do
-			start_time = Date.new(2009,11)
-			end_time = Date.new(2011,1)
-			expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years=>1, :months=>2, :weeks=>0, :days=>0, :hours=>18, :minutes=>0, :seconds=>0})
-		end
-	
-		it "returns time difference based on Wolfram Alpha" do
-			start_time = Date.new(2011,1)
-			end_time = Date.new(2011,12)
-			expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
-			expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
-			expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
-			expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
-			expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
-			expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
-		end
-	
-		it "returns time difference in absolute value regardless how it is minus-ed out" do
-			start_time = Date.new(2011,1)
-			end_time = Date.new(2011,12)
-			expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
-			expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
-			expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
-			expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
-			expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
-			expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
-		end
+  context "with DateTime class" do
 
-	end
+    it "returns time difference in each component" do
+      start_time = DateTime.new(2011, 1)
+      end_time = DateTime.new(2011, 12)
+      expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years => 0.91, :months => 10.98, :weeks => 47.71, :days => 334.0, :hours => 8016.0, :minutes => 480960.0, :seconds => 28857600.0})
+    end
+
+    it "returns time difference in general that matches the total seconds" do
+      start_time = DateTime.new(2009, 11)
+      end_time = DateTime.new(2011, 1)
+      expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years => 1, :months => 2, :weeks => 0, :days => 0, :hours => 18, :minutes => 0, :seconds => 0})
+    end
+
+    it "returns time difference based on Wolfram Alpha" do
+      start_time = DateTime.new(2011, 1)
+      end_time = DateTime.new(2011, 12)
+      expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
+      expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
+      expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
+      expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
+      expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
+      expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
+    end
+
+    it "returns time difference in absolute value regardless how it is minus-ed out" do
+      start_time = DateTime.new(2011, 1)
+      end_time = DateTime.new(2011, 12)
+      expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
+      expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
+      expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
+      expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
+      expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
+      expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
+    end
+
+  end
+
+  context "Date class" do
+    it "returns time difference in each component" do
+      start_time = Date.new(2011, 1)
+      end_time = Date.new(2011, 12)
+      expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({:years => 0.91, :months => 10.98, :weeks => 47.71, :days => 334.0, :hours => 8016.0, :minutes => 480960.0, :seconds => 28857600.0})
+    end
+
+    it "returns time difference in general that matches the total seconds" do
+      start_time = Date.new(2009, 11)
+      end_time = Date.new(2011, 1)
+      expect(TimeDifference.between(start_time, end_time).in_general).to eql({:years => 1, :months => 2, :weeks => 0, :days => 0, :hours => 18, :minutes => 0, :seconds => 0})
+    end
+
+    it "returns time difference based on Wolfram Alpha" do
+      start_time = Date.new(2011, 1)
+      end_time = Date.new(2011, 12)
+      expect(TimeDifference.between(start_time, end_time).in_years).to eql 0.91
+      expect(TimeDifference.between(start_time, end_time).in_months).to eql 10.98
+      expect(TimeDifference.between(start_time, end_time).in_weeks).to eql 47.71
+      expect(TimeDifference.between(start_time, end_time).in_days).to eql 334.0
+      expect(TimeDifference.between(start_time, end_time).in_hours).to eql 8016.0
+      expect(TimeDifference.between(start_time, end_time).in_minutes).to eql 480960.0
+    end
+
+    it "returns time difference in absolute value regardless how it is minus-ed out" do
+      start_time = Date.new(2011, 1)
+      end_time = Date.new(2011, 12)
+      expect(TimeDifference.between(end_time, start_time).in_years).to eql 0.91
+      expect(TimeDifference.between(end_time, start_time).in_months).to eql 10.98
+      expect(TimeDifference.between(end_time, start_time).in_weeks).to eql 47.71
+      expect(TimeDifference.between(end_time, start_time).in_days).to eql 334.0
+      expect(TimeDifference.between(end_time, start_time).in_hours).to eql 8016.0
+      expect(TimeDifference.between(end_time, start_time).in_minutes).to eql 480960.0
+    end
+
+  end
 
 end


### PR DESCRIPTION
I've continued on your work on the datetime_class branch fixing issue #5. When using ActiveSupport 3.2 calling #to_time isn't enough when it has an offset, calling #to_f on the result fixes this.
I've also made some more changes to the code base, but it is still compatible with the current version.
This closes #5.

Martin