### PR TITLE
Add an extra day to the time difference for leap years

### DIFF
--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -57,12 +57,13 @@ class TimeDifference
   end
 
   private
-  
-  def initialize(start_time, end_time)
-    start_time = time_in_seconds(start_time)
-    end_time = time_in_seconds(end_time)
 
-    @time_diff = (end_time - start_time).abs
+  def initialize(start_time, end_time)
+    start_time_in_seconds = time_in_seconds(start_time)
+    end_time_in_seconds = time_in_seconds(end_time)
+
+    @time_diff = (end_time_in_seconds - start_time_in_seconds).abs
+    @time_diff += 86400 if include_leap_year_day?(start_time, end_time)
   end
 
   def time_in_seconds(time)
@@ -71,6 +72,12 @@ class TimeDifference
 
   def in_component(component)
     (@time_diff / 1.send(component)).round(2)
+  end
+
+  def include_leap_year_day?(start_date, end_date)
+    start_date = start_date.to_date
+    end_date = end_date.to_date
+    (start_date..end_date).select{ |date| date.month == 2 && date.day > 28 }.any? && in_days >= 1.0
   end
 
 end

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -76,6 +76,29 @@ describe TimeDifference do
 
         expect(TimeDifference.between(start_time, end_time).in_months).to eql(10.98)
       end
+
+      context "in a leap year" do
+        it "adds an extra day to cover 29th February" do
+          start_time = clazz.new(2012, 1)
+          end_time = clazz.new(2012, 3)
+
+          expect(TimeDifference.between(start_time, end_time).in_months).to eql(2.01)
+        end
+
+        it "does not add an extra day if the difference is within the 29th February" do
+          start_time = clazz.new(2012, 2, 29, 1)
+          end_time = clazz.new(2012, 2, 29, 2)
+
+          expect(TimeDifference.between(start_time, end_time).in_months).to eql(0.0)
+        end
+
+        it "doesn't add a day when the date period does not cover 29th February" do
+          start_time = clazz.new(2012, 3, 27)
+          end_time = clazz.new(2012, 4, 27)
+
+          expect(TimeDifference.between(start_time, end_time).in_months).to eql(1.02)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
The problem:

``` ruby
TimeDifference.between(Date.new(2016,1,27), Date.new(2016,3,27)).in_months
1.97
```

vs

``` ruby
TimeDifference.between(Date.new(2016,3,27), Date.new(2016,5,27)).in_months
2.0
```

If the time difference period covers the 29th February and is for 1 day or
greater, than ensure an extra 86400 (1 day in seconds) is added to the
time difference to ensure the correct number of months is calculated in the
time difference.
