### PR TITLE
add in_max_unit

### DIFF
--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -45,6 +45,19 @@ class TimeDifference
     end]
   end
 
+  def in_max_unit
+    in_each_component.each do |k,v|
+      if v >= 1
+        amount = v.round
+        unit = amount == 1 ? k.to_s.singularize : k
+
+        return "#{amount} #{unit}"
+      end
+    end
+
+    "0 seconds"
+  end
+
   def in_general
     remaining = @time_diff
 

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -168,4 +168,56 @@ describe TimeDifference do
       end
     end
   end
+
+  describe "#in_max_unit" do
+    with_each_class do |clazz|
+      it "handles years" do
+        start_time = clazz.new(2011, 1)
+        end_time = clazz.new(2012, 1)
+
+        expect(TimeDifference.between(start_time, end_time).in_max_unit).to eql("1 year")
+        
+        start_time = clazz.new(2011, 1)
+        end_time = clazz.new(2014, 1)
+
+        expect(TimeDifference.between(start_time, end_time).in_max_unit).to eql("3 years")
+      end
+
+      it "handles months" do
+        start_time = clazz.new(2011, 1)
+        end_time = clazz.new(2011, 2)
+
+        expect(TimeDifference.between(start_time, end_time).in_max_unit).to eql("1 month")
+        
+        start_time = clazz.new(2011, 1)
+        end_time = clazz.new(2011, 4)
+
+        expect(TimeDifference.between(start_time, end_time).in_max_unit).to eql("3 months")
+      end
+      
+      it "handles weeks" do
+        start_time = clazz.new(2011, 1, 1)
+        end_time = clazz.new(2011, 1, 8)
+
+        expect(TimeDifference.between(start_time, end_time).in_max_unit).to eql("1 week")
+        
+        start_time = clazz.new(2011, 1, 1)
+        end_time = clazz.new(2011, 1, 22)
+
+        expect(TimeDifference.between(start_time, end_time).in_max_unit).to eql("3 weeks")
+      end
+      
+      it "handles days" do
+        start_time = clazz.new(2011, 1, 1)
+        end_time = clazz.new(2011, 1, 2)
+
+        expect(TimeDifference.between(start_time, end_time).in_max_unit).to eql("1 day")
+        
+        start_time = clazz.new(2011, 1, 1)
+        end_time = clazz.new(2011, 1, 4)
+
+        expect(TimeDifference.between(start_time, end_time).in_max_unit).to eql("3 days")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows to get a gross estimation of the time, as you would in a
conversation. For example: 1 year, 3 months, etc.

Signed-off-by: Dimid Duchovny dimidd@gmail.com
