### PR TITLE
Abs as option

### DIFF
--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -7,8 +7,8 @@ class TimeDifference
 
   TIME_COMPONENTS = [:years, :months, :weeks, :days, :hours, :minutes, :seconds]
 
-  def self.between(start_time, end_time)
-    new(start_time, end_time)
+  def self.between(end_time, start_time, abs = true)
+    new(end_time, start_time, abs)
   end
 
   def in_years
@@ -58,11 +58,12 @@ class TimeDifference
 
   private
   
-  def initialize(start_time, end_time)
-    start_time = time_in_seconds(start_time)
+  def initialize(end_time, start_time, abs)
     end_time = time_in_seconds(end_time)
+    start_time = time_in_seconds(start_time)
 
-    @time_diff = (end_time - start_time).abs
+    @time_diff = (end_time - start_time)
+    @time_diff = @time_diff.abs if abs
   end
 
   def time_in_seconds(time)

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -17,7 +17,7 @@ describe TimeDifference do
       start_time = Time.new(2011, 1)
       end_time = Time.new(2011, 12)
 
-      expect(TimeDifference.between(start_time, end_time)).to be_a(TimeDifference)
+      expect(TimeDifference.between(end_time, start_time)).to be_a(TimeDifference)
     end
   end
 
@@ -27,7 +27,7 @@ describe TimeDifference do
         start_time = clazz.new(2011, 1)
         end_time = clazz.new(2011, 12)
 
-        expect(TimeDifference.between(start_time, end_time).in_each_component).to eql({years: 0.91, months: 10.98, weeks: 47.71, days: 334.0, hours: 8016.0, minutes: 480960.0, seconds: 28857600.0})
+        expect(TimeDifference.between(end_time, start_time).in_each_component).to eql({years: 0.91, months: 10.98, weeks: 47.71, days: 334.0, hours: 8016.0, minutes: 480960.0, seconds: 28857600.0})
       end
     end
   end
@@ -38,7 +38,7 @@ describe TimeDifference do
         start_time = clazz.new(2009, 11)
         end_time = clazz.new(2011, 1)
 
-        expect(TimeDifference.between(start_time, end_time).in_general).to eql({years: 1, months: 2, weeks: 0, days: 0, hours: 18, minutes: 0, seconds: 0})
+        expect(TimeDifference.between(end_time, start_time).in_general).to eql({years: 1, months: 2, weeks: 0, days: 0, hours: 18, minutes: 0, seconds: 0})
       end
     end
   end
@@ -49,14 +49,21 @@ describe TimeDifference do
         start_time = clazz.new(2011, 1)
         end_time = clazz.new(2011, 12)
 
-        expect(TimeDifference.between(start_time, end_time).in_years).to eql(0.91)
+        expect(TimeDifference.between(end_time, start_time).in_years).to eql(0.91)
       end
 
       it "returns an absolute difference" do
         start_time = clazz.new(2011, 12)
         end_time = clazz.new(2011, 1)
 
-        expect(TimeDifference.between(start_time, end_time).in_years).to eql(0.91)
+        expect(TimeDifference.between(end_time, start_time).in_years).to eql(0.91)
+      end
+
+      it "returns a not absolute difference when 'abs = false'" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(end_time, start_time, false).in_years).to eql(-0.91)
       end
     end
   end
@@ -67,14 +74,21 @@ describe TimeDifference do
         start_time = clazz.new(2011, 1)
         end_time = clazz.new(2011, 12)
 
-        expect(TimeDifference.between(start_time, end_time).in_months).to eql(10.98)
+        expect(TimeDifference.between(end_time, start_time).in_months).to eql(10.98)
       end
 
       it "returns an absolute difference" do
         start_time = clazz.new(2011, 12)
         end_time = clazz.new(2011, 1)
 
-        expect(TimeDifference.between(start_time, end_time).in_months).to eql(10.98)
+        expect(TimeDifference.between(end_time, start_time).in_months).to eql(10.98)
+      end
+
+      it "returns a not absolute difference when 'abs = false'" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(end_time, start_time, false).in_months).to eql(-10.98)
       end
     end
   end
@@ -85,14 +99,21 @@ describe TimeDifference do
         start_time = clazz.new(2011, 1)
         end_time = clazz.new(2011, 12)
 
-        expect(TimeDifference.between(start_time, end_time).in_weeks).to eql(47.71)
+        expect(TimeDifference.between(end_time, start_time).in_weeks).to eql(47.71)
       end
 
       it "returns an absolute difference" do
         start_time = clazz.new(2011, 12)
         end_time = clazz.new(2011, 1)
 
-        expect(TimeDifference.between(start_time, end_time).in_weeks).to eql(47.71)
+        expect(TimeDifference.between(end_time, start_time).in_weeks).to eql(47.71)
+      end
+
+      it "returns a not absolute difference when 'abs = false'" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(end_time, start_time, false).in_weeks).to eql(-47.71)
       end
     end
   end
@@ -103,14 +124,21 @@ describe TimeDifference do
         start_time = clazz.new(2011, 1)
         end_time = clazz.new(2011, 12)
 
-        expect(TimeDifference.between(start_time, end_time).in_days).to eql(334.0)
+        expect(TimeDifference.between(end_time, start_time).in_days).to eql(334.0)
       end
 
       it "returns an absolute difference" do
         start_time = clazz.new(2011, 12)
         end_time = clazz.new(2011, 1)
 
-        expect(TimeDifference.between(start_time, end_time).in_days).to eql(334.0)
+        expect(TimeDifference.between(end_time, start_time).in_days).to eql(334.0)
+      end
+
+      it "returns a not absolute difference when 'abs = false'" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(end_time, start_time, false).in_days).to eql(-334.0)
       end
     end
   end
@@ -121,14 +149,21 @@ describe TimeDifference do
         start_time = clazz.new(2011, 1)
         end_time = clazz.new(2011, 12)
 
-        expect(TimeDifference.between(start_time, end_time).in_hours).to eql(8016.0)
+        expect(TimeDifference.between(end_time, start_time).in_hours).to eql(8016.0)
       end
 
       it "returns an absolute difference" do
         start_time = clazz.new(2011, 12)
         end_time = clazz.new(2011, 1)
 
-        expect(TimeDifference.between(start_time, end_time).in_hours).to eql(8016.0)
+        expect(TimeDifference.between(end_time, start_time).in_hours).to eql(8016.0)
+      end
+
+      it "returns a not absolute difference when 'abs = false'" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(end_time, start_time, false).in_hours).to eql(-8016.0)
       end
     end
   end
@@ -139,14 +174,21 @@ describe TimeDifference do
         start_time = clazz.new(2011, 1)
         end_time = clazz.new(2011, 12)
 
-        expect(TimeDifference.between(start_time, end_time).in_minutes).to eql(480960.0)
+        expect(TimeDifference.between(end_time, start_time).in_minutes).to eql(480960.0)
       end
 
       it "returns an absolute difference" do
         start_time = clazz.new(2011, 12)
         end_time = clazz.new(2011, 1)
 
-        expect(TimeDifference.between(start_time, end_time).in_minutes).to eql(480960.0)
+        expect(TimeDifference.between(end_time, start_time).in_minutes).to eql(480960.0)
+      end
+
+      it "returns a not absolute difference when 'abs = false'" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(end_time, start_time, false).in_minutes).to eql(-480960.0)
       end
     end
   end
@@ -157,14 +199,21 @@ describe TimeDifference do
         start_time = clazz.new(2011, 1)
         end_time = clazz.new(2011, 12)
 
-        expect(TimeDifference.between(start_time, end_time).in_seconds).to eql(28857600.0)
+        expect(TimeDifference.between(end_time, start_time).in_seconds).to eql(28857600.0)
       end
 
       it "returns an absolute difference" do
         start_time = clazz.new(2011, 12)
         end_time = clazz.new(2011, 1)
 
-        expect(TimeDifference.between(start_time, end_time).in_seconds).to eql(28857600.0)
+        expect(TimeDifference.between(end_time, start_time).in_seconds).to eql(28857600.0)
+      end
+
+      it "returns a not absolute difference when 'abs = false'" do
+        start_time = clazz.new(2011, 12)
+        end_time = clazz.new(2011, 1)
+
+        expect(TimeDifference.between(end_time, start_time, false).in_seconds).to eql(-28857600.0)
       end
     end
   end


### PR DESCRIPTION
As a user, I need to get a not abs value sometimes.
So, I added abs as a third param of between method.

The order of param is changed because it's more familiar.
There is no side effects to existing user.

Thanks.
