### PR TITLE
Add an in_calendar_months feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ TimeDifference.between(start_time, end_time).in_years
 TimeDifference.between(start_time, end_time).in_months
 => 12.0
 
+TimeDifference.between(start_time, end_time).in_calendar_months
+=> 12.0
+
 TimeDifference.between(start_time, end_time).in_weeks
 => 52.14 
 

--- a/lib/time_difference.rb
+++ b/lib/time_difference.rb
@@ -18,6 +18,10 @@ class TimeDifference
   def in_months
     (@time_diff / (1.day * 30.42)).round(2)
   end
+  
+  def in_calendar_months
+    months_between(@start_time, @end_time)
+  end
 
   def in_weeks
     in_component(:weeks)
@@ -82,10 +86,13 @@ class TimeDifference
   private
 
   def initialize(start_time, end_time)
-    start_time = time_in_seconds(start_time)
-    end_time = time_in_seconds(end_time)
+    @start_time = start_time.to_time
+    @end_time = end_time.to_time
+    
+    start_time_s = time_in_seconds(start_time)
+    end_time_s = time_in_seconds(end_time)
 
-    @time_diff = (end_time - start_time).abs
+    @time_diff = (end_time_s - start_time_s).abs
   end
 
   def time_in_seconds(time)
@@ -94,6 +101,19 @@ class TimeDifference
 
   def in_component(component)
     (@time_diff / 1.send(component)).round(2)
+  end
+  
+  def months_between(t1, t2)
+    months_excl_days = (t2.year*12 + t2.month) - (t1.year*12 + t1.month)
+    if t2.day > t1.day
+      months_excl_days
+    elsif t2.day < t1.day
+      months_excl_days - 1
+    elsif t2.seconds_since_midnight >= t1.seconds_since_midnight
+      months_excl_days
+    else
+      months_excl_days - 1
+    end
   end
 
 end

--- a/spec/time_difference_spec.rb
+++ b/spec/time_difference_spec.rb
@@ -181,4 +181,58 @@ describe TimeDifference do
       end
     end
   end
+  
+  describe '#in_calendar_months' do
+    with_each_class do |clazz|
+      it 'considers Sep-4 to Dec-4 to be 3 months' do
+        start_time = clazz.new(2017, 9, 4)
+        end_time = clazz.new(2017, 12, 4)
+      
+        expect(TimeDifference.between(start_time, end_time).in_calendar_months).to eq(3)
+      end
+      it 'considers Aug-4 to Nov-4 to be 3 months' do
+        start_time = clazz.new(2017, 8, 4)
+        end_time = clazz.new(2017, 11, 4)
+      
+        expect(TimeDifference.between(start_time, end_time).in_calendar_months).to eq(3)
+      end
+      it 'considers Sep-4 to Dec-3 to be 2 months' do
+        start_time = clazz.new(2017, 9, 4)
+        end_time = clazz.new(2017, 12, 3)
+      
+        expect(TimeDifference.between(start_time, end_time).in_calendar_months).to eq(2)
+      end
+      it 'considers Sep-4 to Dec-31 to be 3 months' do
+        start_time = clazz.new(2017, 9, 4)
+        end_time = clazz.new(2017, 12, 31)
+      
+        expect(TimeDifference.between(start_time, end_time).in_calendar_months).to eq(3)
+      end
+      it 'considers 2016-Sep-4 to 2017-Sep-4 to be 12 months' do
+        start_time = clazz.new(2016, 9, 4)
+        end_time = clazz.new(2017, 9, 4)
+      
+        expect(TimeDifference.between(start_time, end_time).in_calendar_months).to eq(12)
+      end
+      it 'considers 2016-Sep-4 to 2017-Dec-31 to be 15 months' do
+        start_time = clazz.new(2016, 9, 4)
+        end_time = clazz.new(2017, 12, 31)
+      
+        expect(TimeDifference.between(start_time, end_time).in_calendar_months).to eq(15)
+      end
+    end
+    it 'counts months on the day when time2 > time1' do
+      start_time = Time.new(2017, 9, 4, 12, 15)
+      end_time = Time.new(2017, 12, 4, 12, 22)
+      
+      expect(TimeDifference.between(start_time, end_time).in_calendar_months).to eq(3)
+    end
+    it 'does not count months on the day when time2 < time1' do
+      start_time = Time.new(2017, 9, 4, 12, 15)
+      end_time = Time.new(2017, 12, 4, 12, 10)
+      
+      expect(TimeDifference.between(start_time, end_time).in_calendar_months).to eq(2)
+    end
+  end
+  
 end


### PR DESCRIPTION
This adds a method that does a more "human" calculation of months, taking into account calendar time in the current timezone (so you always get an integer number of months and the 4th of the month to the 4th of the month is always 1 month).

It doesn't touch in_components or in_general and it could probably be refactored slightly to be a shorter method, but it does the job I need!

Let me know what you think or if you'd like me to change anything.