### PR TITLE
ActiveSupport >=5.1 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,25 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
+  - 2.5
+  - 2.6
+  - jruby
   - jruby-19mode # JRuby in 1.9 mode
+matrix:
+  exclude:
+    - rvm: 2.2
+      gemfile: Gemfile.activesupport60
+    - rvm: 2.3
+      gemfile: Gemfile.activesupport60
+    - rvm: 2.4
+      gemfile: Gemfile.activesupport60
+    - rvm: jruby-19mode
+      gemfile: Gemfile.activesupport60
 # uncomment this line if your project needs to run something other than `rake`:
 script: bundle exec rspec spec
 gemfile:
   - Gemfile.activesupport51
+  - Gemfile.activesupport60
 
 before_install:
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,3 @@ script: bundle exec rspec spec
 gemfile:
   - Gemfile.activesupport51
   - Gemfile.activesupport60
-
-before_install:
-  - gem install bundler

--- a/Gemfile.activesupport60
+++ b/Gemfile.activesupport60
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gemspec
+
+gem 'activesupport', '~> 6.0'

--- a/time_difference.gemspec
+++ b/time_difference.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.version       = "0.7.0"
   gem.license = 'MIT'
 
-  gem.add_runtime_dependency('activesupport', '~> 5.1')
+  gem.add_runtime_dependency('activesupport', '>= 5.1')
   gem.add_development_dependency('rspec', '~> 3.7.0')
   gem.add_development_dependency('rake')
 


### PR DESCRIPTION
Adds support for active support 6, whilst maintaining compatibility with active support 5 and older ruby versions.